### PR TITLE
🐛 Fixes relative path issue

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -88,7 +88,7 @@ if (!targetDir) {
   const stringArgs = cliArgs.join(' ');
 
   for (const fileName of files) {
-    execSync(`node ./node_modules/carbon-now-cli/cli ${fileName} ${stringArgs}`, { stdio: 'inherit' });
+    execSync(`node ${__dirname}/node_modules/carbon-now-cli/cli ${fileName} ${stringArgs}`, { stdio: 'inherit' });
     console.log(green(`\nProcessed ${fileName}!\n`));
   }
 })();


### PR DESCRIPTION
`/node_modules/carbon-now-cli/cli` was always relative to where `carbon-now-dir` was executed, e.g. `~/Desktop/node_modules/carbon-now-cli/cli`, instead of where the `carbon-now-dir` binary lied — prepending `__dirname` fixes this. :)

<img width="1324" alt="Screenshot 2019-03-23 at 13 11 07" src="https://user-images.githubusercontent.com/672237/54865891-2dff7080-4d6d-11e9-8e8f-ac5cc1059147.png">
